### PR TITLE
Remove from result a lot of positions after shortish

### DIFF
--- a/src/worker/format.ts
+++ b/src/worker/format.ts
@@ -46,7 +46,9 @@ export function short(text: string, score: Score): [string, Position[]] {
     const head = before.length > SHORT_HEAD ? '...' + before.slice(-SHORT_HEAD) : before;
     const tail = after.slice(0, Math.max(0, MAX_LENGTH - head.length - content.length));
 
-    return [head + content + tail, remap(position[0] - head.length, positions)];
+    const result = head + content + tail;
+
+    return [result, remap(position[0] - head.length, positions, result.length)];
 }
 
 export function long(text: string, score: Score): [string, Position[]] {
@@ -77,7 +79,7 @@ export function long(text: string, score: Score): [string, Position[]] {
     result = result.trimStart();
     head -= length - result.length;
 
-    return [result, remap(head, positions)];
+    return [result, remap(head, positions, result.length)];
 
     function prepend() {
         if (befores.length) {
@@ -119,8 +121,8 @@ function split(text: string, position: Position) {
     return [before, content, after];
 }
 
-function remap(dl: number, positions: Position[]): Position[] {
+function remap(dl: number, positions: Position[], length: number): Position[] {
     return positions
         .map(([start, end]) => [start - dl, end - dl])
-        .filter(([start]) => start >= 0) as [number, number][];
+        .filter(([start]) => start >= 0 && start <= length) as [number, number][];
 }

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -1,5 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`suggest should format very long result 1`] = `
+Array [
+  "
+    <a href=\\"./8\\">
+        <div></div>
+        <div><span class=\\"mark\\">Lorem ipsum</span> dolor <span class=\\"mark\\">Lorem ipsum</span> dolor <span class=\\"mark\\">Lorem ipsum</span> dolor <span class=\\"mark\\">Lorem ipsum</span> dolor <span class=\\"mark\\">Lorem ipsum</span> dolor <span class=\\"mark\\">Lorem ipsum</span> dolor <span class=\\"mark\\">Lorem ipsum</span> dolor <span class=\\"mark\\">Lorem ipsum</span> dolor <span class=\\"mark\\">Lorem ipsum</span> dolor <span class=\\"mark\\">Lorem ipsum</span> dolor <span class=\\"mark\\">Lorem ipsum</span> dolor <span class=\\"mark\\">Lo</span></div>
+    </a>
+",
+]
+`;
+
 exports[`suggest should match code 1`] = `
 Array [
   "

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -18,6 +18,8 @@ const Lorem = [
     'Aenean lobortis ligula a mauris posuere, luctus pretium mauris ultrices.',
 ];
 
+const LongLorem = 'Lorem ipsum dolor '.repeat(100);
+
 const Code = 'crm.stagehistory.list';
 
 const item = ({link, title, description}: SearchSuggestPageItem) => `
@@ -86,5 +88,13 @@ describe('suggest', () => {
         const config = {confidence: 'phrased', tolerance: 2} as const;
 
         expect(suggest('stagehistory', config)).toMatchSnapshot();
+    });
+
+    it('should format very long result', () => {
+        add(LongLorem);
+
+        const config = {confidence: 'phrased', tolerance: 0} as const;
+
+        expect(suggest('Lorem ipsum', config)).toMatchSnapshot();
     });
 });


### PR DESCRIPTION
The line is shortened but the positions that were in the original line remain. If the original text had many matches and was very long, then format adds a lot of empty span to the end of suggest