### PR TITLE
fix:diplodoc-platform/cli/issues/895

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,7 +1,7 @@
 export const MERGE_TOLERANCE = 5;
 
 export const INDEX_FIELDS = {
-    title: 5,
-    keywords: 4,
-    content: 3,
+    title: 10,
+    keywords: 8,
+    content: 1,
 };

--- a/src/worker/score.ts
+++ b/src/worker/score.ts
@@ -125,14 +125,14 @@ export function phrased(result: Index.Result, terms: string[]) {
     function match() {
         const {prev, curr} = state;
 
-        state.score += 2;
+        state.score += 2 * curr.boost; // Take into account boost for better score estimation
 
         if (!prev) {
             return nextToken;
         }
 
         if (isPhrase(phrase, state.phrase, distance(prev.position, curr.position))) {
-            state.score += 10;
+            state.score += 10 * curr.boost; // Take into account boost for better score estimation
             state.position[1] = curr.position[1];
 
             return nextToken;


### PR DESCRIPTION
# diplocodoc-platform/cli/issues/895
Причиной такого поведения встроенного поиска была связана с достаточно маленькой разницей значений boost для title и content, а также значением merge tolerance(расстояние между токенами).
  
Из-за того, что значение MERGE_TOLERANCE равен 5 и значение content было равным 3, последовательность токенов засчиталась фразой и увеличила метрику score для content

В своём решении я внёс изменения в пару файлов

``` js
// constants.js
export const MERGE_TOLERANCE = 5;

export const INDEX_FIELDS = {
    title: 10, // Увеличил для большего веса текста
    keywords: 8, // Увеличил для большего веса ключевых слов
    content: 1, // Уменьшил, чтобы не получилось ситуации, при котором код считает последовательность "ФРАЗОЙ" и не перевесил title
};

```
``` js
// worker/score.ts
export function phrased(){
//...
function match() {
        const {prev, curr} = state;

        state.score += 2 * curr.boost; // Умножаем на метрику boost, чтобы придать веса для title

        if (!prev) {
            return nextToken;
        }

        if (isPhrase(phrase, state.phrase, distance(prev.position, curr.position))) {
            state.score += 10 * curr.boost; // Умножаем на метрику boost, чтобы придать веса для title
            state.position[1] = curr.position[1];

            return nextToken;
        }

        return nextScore;
    }
//...
}
```